### PR TITLE
don't crash if running on gnome-boxes

### DIFF
--- a/usr/bin/auto-gdk-scale
+++ b/usr/bin/auto-gdk-scale
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-MONITOR_WIDTH=$(xrandr | grep -w "connected primary" | sed 's/.*) \(.*\)mm x .*mm/\1/g')
+MONITOR_WIDTH=$(xrandr | grep -w "connected primary" | sed 's/.* \(.*\)mm x .*mm/\1/g')
 if [ "$MONITOR_WIDTH" -eq 0 ]
 then
 	# seen in VirtualBox


### PR DESCRIPTION
`xrandr` reports this while running inside boxes: `Virtual-0 connected primary 1918x1035+0+0 0mm x 0mm`, so `sed` doesn't  find the numeric value, removing the bracket in the lookup fixes this.